### PR TITLE
Add CSS to the modal overlay

### DIFF
--- a/src/components/ModalActions/_modalActions.module.scss
+++ b/src/components/ModalActions/_modalActions.module.scss
@@ -1,0 +1,4 @@
+.ReactModal__Overlay--after-open{
+    background: rgba(53, 53, 53, 0.4)!important;
+    backdrop-filter: blur(5px)!important;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -50,3 +50,4 @@
 @import "../components/TableGain/tableGain";
 @import "../components/ButtonsFilterWrapper/buttonsFilterWrapper";
 @import "../components/ButtonBuy/buttonBuy.scss";
+@import "../components/ModalActions/modalActions.module";


### PR DESCRIPTION
Just add this CSS;

.ReactModal__Overlay--after-open{
    background: rgba(53, 53, 53, 0.4)!important;
    backdrop-filter: blur(5px)!important;
}

Could be better with bodyOpenClassName property, but I tried and it doesn't work. Thus, we could remove the !important