### PR TITLE
fix: :bug: (RanksForm.jsx) Fix bug of créating the new ranks

### DIFF
--- a/src/components/RanksForm/RanksForm.jsx
+++ b/src/components/RanksForm/RanksForm.jsx
@@ -148,9 +148,14 @@ const RanksForm = () => {
     event.preventDefault();
 
     const rankIndex = ranks.findIndex((rank) => rank.id === rankId);
+    console.log({ rankIndex });
     const newRanks = [...ranks];
 
-    const oldLabel = ranks[rankIndex].label;
+    let oldLabel = "";
+
+    if (rankIndex > -1) {
+      oldLabel = ranks[rankIndex].label;
+    }
 
     const verifIfOnePermissionIsChecked = Object.values(rank.permissions).some(
       (value) => value,


### PR DESCRIPTION
The const oldLabel is undefined because we do not modify an existing grade. When creating a new grade => oldLabel = ' '. Creating a new grade is functional